### PR TITLE
Move IS_IPAD out of the .pch file

### DIFF
--- a/KZColorPicker/ColorPicker/KZColorPicker.m
+++ b/KZColorPicker/ColorPicker/KZColorPicker.m
@@ -16,6 +16,8 @@
 #import "KZColorPickerSwatchView.h"
 #import "KZColorCompareView.h"
 
+#define IS_IPAD ([[UIDevice currentDevice] respondsToSelector:@selector(userInterfaceIdiom)] && [[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad)
+
 @interface KZColorPicker()
 @property (nonatomic, retain) KZColorPickerHSWheel *colorWheel;
 @property (nonatomic, retain) KZColorPickerBrightnessSlider *brightnessSlider;

--- a/KZColorPicker/KZColorPicker-Prefix.pch
+++ b/KZColorPicker/KZColorPicker-Prefix.pch
@@ -12,5 +12,4 @@
     #import <UIKit/UIKit.h>
     #import <Foundation/Foundation.h>
 
-#define IS_IPAD ([[UIDevice currentDevice] respondsToSelector:@selector(userInterfaceIdiom)] && [[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad)
 #endif


### PR DESCRIPTION
Moved IS_IPAD from the .pch file to KZColorPicker so that the control can be used in other projects. I ran into an issue while trying to use the control with CocoaPods
